### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "cpp11"
+run = "make && ./mine"

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Run on Repl.it](https://repl.it/badge/github/unknownblueguy6/MineSweeper)](https://repl.it/github/unknownblueguy6/MineSweeper)
+
 # MineSweeper
 
 Command Line version of MineSweeper for Unix-like systems (GNU/Linux, macOS, BSD).


### PR DESCRIPTION
It's really easy to run this in browser through repl.it, let me know if you'd consider adding the badge :)

![Capture](https://user-images.githubusercontent.com/39810066/70538260-cc1bac80-1b2f-11ea-897a-ad657aa128ac.PNG)

_"This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@dialogarithm/MineSweeper-1)."_