### PR TITLE
Added release and debug options with optimizations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,5 +5,10 @@ CC = g++
 
 OBJ_NAME = mine
 
-all :
-	$(CC) $(OBJS) -std=c++11 -o $(OBJ_NAME)
+all : release
+
+release:
+	$(CC) $(OBJS) -std=c++11 -O3 -o $(OBJ_NAME)
+
+debug:
+	$(CC) $(OBJS) -std=c++11 -O0 -o $(OBJ_NAME)


### PR DESCRIPTION
Now you can do:
 * `make`: Same as `make release`
 * `make release`: Compile with all optimizations enabled (`-O3`) &rarr; Faster and smaller program, but slower compilation
 * `make debug`: Compile with all optimizations desabled, for debugging purposes &rarr; The resulting program has minimal changes with respect to the codebase