### PR TITLE
Replaced `system("clear")`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,17 @@
-[![Run on Repl.it](https://repl.it/badge/github/unknownblueguy6/MineSweeper)](https://repl.it/github/unknownblueguy6/MineSweeper)
-
 # MineSweeper
-
 Command Line version of MineSweeper for Unix-like systems (GNU/Linux, macOS, BSD).
+
+This is a fork, but [the original project](https://github.com/unknownblueguy6/MineSweeper) seems dead. I will gladly delete this once the changes are accepted/rejected.
 
 <p align="center">
     <img align="center" src="assets/demo.gif"></img>
 </p>
+
+## Enhancements
+* AUR support (I created an AUR installer)
+* Better mechanism for clearing the screen (faster, compatible with all Operating Systems)
+* Improved the Makefile, with an option for the release version with optimizations enabled.
+
 
 ## Prerequisites
 1. C++11 compiler

--- a/source/field.hpp
+++ b/source/field.hpp
@@ -612,5 +612,7 @@ void Field::startSweep(int x, int y, POSOFCELL pos, DIR_X x_dir, DIR_Y y_dir)
         cells[x][y].reveal();
         --hiddenCells;
         break;
+    default:
+        break;
     }
 }

--- a/source/mine.cpp
+++ b/source/mine.cpp
@@ -3,10 +3,18 @@
 #include "setup.hpp"
 #include "colour.hpp"
 #include "display.hpp"
+#include <stdio.h>
+
+void clrscr()
+{
+    int n;
+    for (n = 0; n < 10; n++)
+        printf( "\n\n\n\n\n\n\n\n\n\n" );
+}
 
 int main()
 {
-    system("clear");
+    clrscr();
     setGameMode();
     getQuickClearSettings();
 
@@ -14,7 +22,7 @@ int main()
 
     while (true)
     {
-        system("clear");
+        clrscr();
 
         dispBanner();
         field.drawField();


### PR DESCRIPTION
Replaced `system("clear")` with a custom function that just prints 100 newlines. That approach is faster than doing a system call, it is safer and works on any system.

This should solve bug #8 